### PR TITLE
feat: Use POST requests for index_dump.py and index_files.py

### DIFF
--- a/.github/workflows/index_dump.py
+++ b/.github/workflows/index_dump.py
@@ -16,7 +16,7 @@ def set_args():
 
 def send_request(url, headers):
     try:
-        response = requests.get(url,headers=headers)
+        response = requests.post(url,headers=headers)
     except requests.exceptions.RequestException as e:
         raise e
     return response

--- a/.github/workflows/index_files.py
+++ b/.github/workflows/index_files.py
@@ -15,7 +15,7 @@ def set_args():
 
 def send_request(url, headers):
     try:
-        response = requests.get(url,headers=headers)
+        response = requests.post(url,headers=headers)
     except requests.exceptions.RequestException as e:
         raise e
     return response


### PR DESCRIPTION
## Purpose

This PR updates the GitHub Actions workflows for `index_dump.py` and `index_files.py` to use POST requests instead of GET requests when sending data.

## Approach

The `send_request` function in both scripts has been modified to change the HTTP method from `requests.get` to `requests.post`. This change is intended to accommodate potentially larger amounts of data being sent in the request body, which is not suitable for GET requests.

### Key Modifications

*   Changed `requests.get` to `requests.post` in `index_dump.py`.
*   Changed `requests.get` to `requests.post` in `index_files.py`.

### Important Technical Details

This change is significant because GET requests have limitations on URL length and are not designed for sending bodies, whereas POST requests are suitable for sending larger amounts of data.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.